### PR TITLE
comp_spec_eq_rel_* at level 10

### DIFF
--- a/src/FCF/ProgramLogic.v
+++ b/src/FCF/ProgramLogic.v
@@ -2302,7 +2302,13 @@ Qed.
 Require Import Setoid.
 
 Add Parametric Relation (A : Set){eqd : EqDec A} : (Comp A) (@comp_spec A A eqd eqd eq)
-  reflexivity proved by (@comp_spec_eq_refl A eqd)
-  symmetry proved by (@comp_spec_eq_symm A eqd)
-  transitivity proved by (@comp_spec_eq_trans A eqd)
   as comp_spec_eq_rel.
+
+Global Instance comp_spec_eq_rel_Reflexive (A : Set) (eqd : EqDec A) : Reflexive (comp_spec eq)
+  | 10 := @comp_spec_eq_refl A eqd.
+Global Instance comp_spec_eq_rel_Symmetric (A : Set) (eqd : EqDec A) : Symmetric (comp_spec eq)
+  | 10 := @comp_spec_eq_symm A eqd.
+Global Instance comp_spec_eq_rel_Transitive (A : Set) (eqd : EqDec A) : Transitive (comp_spec eq)
+  | 10 := @comp_spec_eq_trans A eqd.
+Global Instance comp_spec_eq_rel (A : Set) (eqd : EqDec A) : Equivalence (comp_spec eq)
+  | 10 := {}.


### PR DESCRIPTION
This makes `setoid_rewrite` work better when FCF has been `Require`-d.