### PR TITLE
Adapting to Coq PR #7257 which fixes a sensitivity of unification wrt alphabetic order

### DIFF
--- a/src/FCF/DistRules.v
+++ b/src/FCF/DistRules.v
@@ -881,8 +881,8 @@ Theorem repeat_unroll_eq: forall (A : Set)(eqd : EqDec A)(c : Comp A)(P : A -> b
   econstructor.
   eauto.
   simpl.
-  econstructor.
-  trivial.
+  2:eassumption.
+  constructor.
   
   inversion H2; clear H2; subst.
   simpl in *.
@@ -923,8 +923,8 @@ Theorem repeat_unroll_eq: forall (A : Set)(eqd : EqDec A)(c : Comp A)(P : A -> b
   econstructor.
   eauto.
   simpl.
-  econstructor.
-  trivial.
+  2:eassumption.
+  constructor.
   
   apply evalDet_steps_bind_eof_inv in H2.
   intuition.


### PR DESCRIPTION
Dear maintainers of FCF,

We realized that Coq unification had a sensitivity on the ASCII order of variable names (!!) and a fix has been prepared coq/coq#7257.

FCF is one of the developments which we track (via cross-crypto) and which exposes the case of a unification problem solved by ordering variable names alphabetically. Indeed, there is in `DistRules.v` a unification problem `?s'@{a:=a; s':=s'; x:=a; x0:=s'} == s'` for which the solution `?s':=s'` is chosen because `s'` comes before `x0` in ASCII order. [To clarify all risk of confusion, the fact that there are 3 distinct uses of the name `s'` in the problem does not matter: one, `?s'` is the name of the evar, one is the name of the variable `s'` in the context of the evar `?s'`, and the third is the name of an eponymous variable in the context of the current goal; otherwise said, the problem could have equivalently be reformulated `?e@{a:=a; s':=S; x:=a; x0:=S} == S` and expose the same two possible solutions `?e:=s'` or `?e:=x0` for `?e`.]

Coq PR coq/coq#7257 makes the solution to this problem independent of the exact names of variables by systematically chosing the most recent name, so, here, `x0`. This breaks the compilation of `DistRules.v`. This PR against FCF provides a backward-compatible fix so that FCF can continue to compile after coq/coq#7257 is merged.

Please tell me if you have any question.