### PR TITLE
Made all the FCF files importable via -Q

### DIFF
--- a/src/FCF/Admissibility.v
+++ b/src/FCF/Admissibility.v
@@ -5,7 +5,7 @@
 (* Some basic definitions used in cost models, admissibility predicates, etc. *)
 Set Implicit Arguments.
 
-Require Import Comp.
+Require Import FCF.Comp.
 
 Definition DataTypeFamily := nat -> Set.
 

--- a/src/FCF/Array.v
+++ b/src/FCF/Array.v
@@ -5,8 +5,8 @@
 (* A general purpose array indexed by an arbitrary type *)
 
 Set Implicit Arguments.
-Require Import Crypto.
-Require Import Fold.
+Require Import FCF.Crypto.
+Require Import FCF.Fold.
 
 Local Open Scope list_scope.
 
@@ -190,7 +190,7 @@ Definition arrayLookupList(A B : Set)(eqd : EqDec A)(ls : list (A * (list B)))(a
       | Some ls => ls
     end.
 
-Require Import CompFold.
+Require Import FCF.CompFold.
 
 Lemma arrayLookup_Some_In_unzip : 
   forall (A B : Set)(eqd : EqDec A)(arr : Array A B) a b,

--- a/src/FCF/Asymptotic.v
+++ b/src/FCF/Asymptotic.v
@@ -6,7 +6,7 @@
 
 Set Implicit Arguments.
 
-Require Import StdNat.
+Require Import FCF.StdNat.
 
 Definition polynomial (f : nat -> nat) :=
     exists x c1 c2, forall n,
@@ -217,7 +217,7 @@ Theorem polynomial_mult :
 Qed.     
       
 
-Require Import Rat.
+Require Import FCF.Rat.
 Local Open Scope rat_scope.
 
 Definition negligible(f : nat -> Rat) :=

--- a/src/FCF/Bernoulli.v
+++ b/src/FCF/Bernoulli.v
@@ -4,9 +4,9 @@
 
 Set Implicit Arguments.
 
-Require Import Crypto.
-Require Import RndNat.
-Require Import NotationV1.
+Require Import FCF.Crypto.
+Require Import FCF.RndNat.
+Require Import FCF.NotationV1.
 
 Definition Bernoulli(r : Rat) : Comp bool :=
   match r with

--- a/src/FCF/Blist.v
+++ b/src/FCF/Blist.v
@@ -5,12 +5,12 @@
 
 Set Implicit Arguments.
 
-Require Import StdNat.
+Require Import FCF.StdNat.
 Require Export List.
 Require Export Bvector.
 Require Import Omega.
-Require Import EqDec.
-Require Import Fold.
+Require Import FCF.EqDec.
+Require Import FCF.Fold.
 Require Import Coq.NArith.Ndigits.
 Require Import ZArith.
 Local Open Scope list_scope.

--- a/src/FCF/Class.v
+++ b/src/FCF/Class.v
@@ -3,10 +3,10 @@
 
 Set Implicit Arguments.
 
-Require Import Crypto.
-Require Import Encryption.
-Require Import CompFold.
-Require Import FCF.
+Require Import FCF.Crypto.
+Require Import FCF.Encryption.
+Require Import FCF.CompFold.
+Require Import FCF.FCF.
 
 Section EncryptClassify.
 

--- a/src/FCF/Comp.v
+++ b/src/FCF/Comp.v
@@ -8,9 +8,9 @@ Set Implicit Arguments.
 
 Require Export Bvector.
 Require Export List.
-Require Export Blist.
-Require Export EqDec.
-Require Import Fold.
+Require Export FCF.Blist.
+Require Export FCF.EqDec.
+Require Import FCF.Fold.
 
 
 Inductive Comp : Set -> Type :=
@@ -61,7 +61,7 @@ Lemma comp_base_exists : forall (A : Set),
   eauto using Bvector_exists.
 Qed.
 
-Require Import EqDec. 
+Require Import FCF.EqDec. 
 
 Lemma comp_EqDec : forall (A : Set),
   Comp A ->

--- a/src/FCF/CompFold.v
+++ b/src/FCF/CompFold.v
@@ -4,7 +4,7 @@
 (* Operations that fold and map a computation over a list, and related theory. *)
 
 Set Implicit Arguments.
-Require Import FCF.
+Require Import FCF.FCF.
 
 Local Open Scope list_scope.
 

--- a/src/FCF/Crypto.v
+++ b/src/FCF/Crypto.v
@@ -3,14 +3,14 @@
  * in the LICENSE file at the root of the source tree.		*)
 (* A top-level module that exports all of the common components of the framework. *)
 
-Require Export DistRules.
-Require Export Comp.
+Require Export FCF.DistRules.
+Require Export FCF.Comp.
 Require Export Arith.
-Require Export Fold.
-Require Export Rat.
-Require Export DistSem.
-Require Export StdNat.
-Require Export DistTacs.
+Require Export FCF.Fold.
+Require Export FCF.Rat.
+Require Export FCF.DistSem.
+Require Export FCF.StdNat.
+Require Export FCF.DistTacs.
 
 
 Open Scope comp_scope.

--- a/src/FCF/DetSem.v
+++ b/src/FCF/DetSem.v
@@ -5,9 +5,9 @@
 
 Set Implicit Arguments.
 
-Require Export Comp.
-Require Import Blist.
-Require Import Fold.
+Require Export FCF.Comp.
+Require Import FCF.Blist.
+Require Import FCF.Fold.
 Require Import Permutation.
 Require Import Omega.
 

--- a/src/FCF/DiffieHellman.v
+++ b/src/FCF/DiffieHellman.v
@@ -6,9 +6,9 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
-Require Import RndNat.
-Require Export GroupTheory.
+Require Import FCF.FCF.
+Require Import FCF.RndNat.
+Require Export FCF.GroupTheory.
 
 Local Open Scope group_scope.
 

--- a/src/FCF/DistRules.v
+++ b/src/FCF/DistRules.v
@@ -5,12 +5,12 @@
 
 Set Implicit Arguments.
 
-Require Import DistSem.
-Require Import Fold.
+Require Import FCF.DistSem.
+Require Import FCF.Fold.
 Require Import Permutation.
-Require Import SemEquiv.
-Require Import DetSem.
-Require Import NotationV1.
+Require Import FCF.SemEquiv.
+Require Import FCF.DetSem.
+Require Import FCF.NotationV1.
 
  
 Local Open Scope rat_scope.

--- a/src/FCF/DistSem.v
+++ b/src/FCF/DistSem.v
@@ -6,14 +6,14 @@
 
 Set Implicit Arguments.
 
-Require Export Comp.
-Require Export Rat.
-Require Import Fold.
+Require Export FCF.Comp.
+Require Export FCF.Rat.
+Require Import FCF.Fold.
 Require Import List.
-Require Import Blist.
+Require Import FCF.Blist.
 Require Import Omega.
-Require Import StdNat.
-Require Import NotationV1.
+Require Import FCF.StdNat.
+Require Import FCF.NotationV1.
  
  
 Local Open Scope list_scope.

--- a/src/FCF/DistTacs.v
+++ b/src/FCF/DistTacs.v
@@ -6,13 +6,13 @@
 
 Set Implicit Arguments.
 
-Require Import Rat.
-Require Import Comp.
-Require Import DistRules.
-Require Import DistSem.
-Require Import StdNat.
-Require Import Fold.
-Require Import NotationV1.
+Require Import FCF.Rat.
+Require Import FCF.Comp.
+Require Import FCF.DistRules.
+Require Import FCF.DistSem.
+Require Import FCF.StdNat.
+Require Import FCF.Fold.
+Require Import FCF.NotationV1.
 
 Local Open Scope rat_scope.
 Local Open Scope comp_scope.

--- a/src/FCF/Encryption.v
+++ b/src/FCF/Encryption.v
@@ -6,9 +6,9 @@
 
 Set Implicit Arguments.
 Unset Strict Implicit.
-Require Import FCF.
-Require Import CompFold.
-Require Export Hybrid.
+Require Import FCF.FCF.
+Require Import FCF.CompFold.
+Require Export FCF.Hybrid.
 
 Local Open Scope type_scope.
 Local Open Scope comp_scope.
@@ -349,8 +349,8 @@ Section Encryption_SecretKey_concrete.
 
 End Encryption_SecretKey_concrete.
 
-Require Import Asymptotic.
-Require Import Admissibility.
+Require Import FCF.Asymptotic.
+Require Import FCF.Admissibility.
 
 Section Encryption_SecretKey.
 

--- a/src/FCF/Encryption_PK.v
+++ b/src/FCF/Encryption_PK.v
@@ -4,7 +4,7 @@
 (* Definitions for public key encryption. *)
 
 Set Implicit Arguments.
-Require Import FCF.
+Require Import FCF.FCF.
 
 Local Open Scope rat_scope.
 Local Open Scope list_scope.

--- a/src/FCF/ExpectedPolyTime.v
+++ b/src/FCF/ExpectedPolyTime.v
@@ -2,9 +2,9 @@
  * in the LICENSE file at the root of the source tree.		*)
 (* An axiomatization of expected polynomial time as a type class.  *)
 
-Require Import Crypto.
-Require Import Asymptotic.
-Require Import FCF.
+Require Import FCF.Crypto.
+Require Import FCF.Asymptotic.
+Require Import FCF.FCF.
 
 Definition procedure_family(A : nat -> Type) := forall n, A n.
 Definition efficiency_predicate := forall (A : nat -> Type), procedure_family A -> Prop.

--- a/src/FCF/FCF.v
+++ b/src/FCF/FCF.v
@@ -1,12 +1,12 @@
 (* Copyright 2012-2015 by Adam Petcher.				*
  * Use of this source code is governed by the license described	*
  * in the LICENSE file at the root of the source tree.		*)
-Require Export Crypto.
-Require Export ProgramLogic.
-Require Export ProgTacs.
-Require Export RndNat.
-Require Export GenTacs.
-Require Export NotationV1.
-Require Export Tactics.
+Require Export FCF.Crypto.
+Require Export FCF.ProgramLogic.
+Require Export FCF.ProgTacs.
+Require Export FCF.RndNat.
+Require Export FCF.GenTacs.
+Require Export FCF.NotationV1.
+Require Export FCF.Tactics.
 
 Open Scope eq_scope.

--- a/src/FCF/Fold.v
+++ b/src/FCF/Fold.v
@@ -5,12 +5,12 @@
 
 Set Implicit Arguments.
 
-Require Import Rat.
+Require Import FCF.Rat.
 Require Import List.
 Require Import Permutation.
 Require Import Arith.
-Require Import EqDec.
-Require Import StdNat.
+Require Import FCF.EqDec.
+Require Import FCF.StdNat.
 Require Import Bool.
 
 Local Open Scope rat_scope.

--- a/src/FCF/GenTacs.v
+++ b/src/FCF/GenTacs.v
@@ -2,9 +2,9 @@
  * Use of this source code is governed by the license described	*
  * in the LICENSE file at the root of the source tree.		*)
 
-Require Import DistTacs.
-Require Import ProgTacs.
-Require Import ProgramLogic.
+Require Import FCF.DistTacs.
+Require Import FCF.ProgTacs.
+Require Import FCF.ProgramLogic.
 
 Ltac inline_first :=
   repeat (dist_inline_first; prog_inline_first).

--- a/src/FCF/GroupTheory.v
+++ b/src/FCF/GroupTheory.v
@@ -6,8 +6,8 @@
 
 Set Implicit Arguments.
 
-Require Import Rat.
-Require Import StdNat.
+Require Import FCF.Rat.
+Require Import FCF.StdNat.
 
 Class Group_op(A : Set) := groupOp : A -> A -> A.
 Infix "*" := groupOp : group_scope.

--- a/src/FCF/HasDups.v
+++ b/src/FCF/HasDups.v
@@ -4,8 +4,8 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
-Require Import CompFold.
+Require Import FCF.FCF.
+Require Import FCF.CompFold.
 Local Open Scope list_scope.
 
 Fixpoint hasDups (A : Set)(eqd : EqDec A)(ls : list A) :=
@@ -107,7 +107,7 @@ Theorem Permutation_hasDups :
      
 Qed.
 
-Require Import RndInList.
+Require Import FCF.RndInList.
 
 Section DupProb.
 

--- a/src/FCF/Hybrid.v
+++ b/src/FCF/Hybrid.v
@@ -4,8 +4,8 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
-Require Import CompFold.
+Require Import FCF.FCF.
+Require Import FCF.CompFold.
 
 Open Scope list_scope.
 

--- a/src/FCF/Limit.v
+++ b/src/FCF/Limit.v
@@ -7,11 +7,11 @@
 Set Implicit Arguments.
 
 Require Import Arith.
-Require Import Fold.
+Require Import FCF.Fold.
 Require Import List.
 
-Require Import StdNat.
-Require Import Rat.
+Require Import FCF.StdNat.
+Require Import FCF.Rat.
 
 Section Limit.
 

--- a/src/FCF/NoDup_gen.v
+++ b/src/FCF/NoDup_gen.v
@@ -4,7 +4,7 @@
 Set Implicit Arguments.
 
 Require Import List.
-Require Import Fold.
+Require Import FCF.Fold.
 
 Section In_gen.
   Variable A : Type.
@@ -211,7 +211,7 @@ Section NoDup_gen_map.
   
 End NoDup_gen_map.
 
-Require Import RepeatCore.
+Require Import FCF.RepeatCore.
  
 Theorem In_gen_weaken : 
   forall (A : Type)(e1 e2 : A -> A -> Prop) ls a,

--- a/src/FCF/NotationV1.v
+++ b/src/FCF/NotationV1.v
@@ -3,7 +3,7 @@
  * in the LICENSE file at the root of the source tree.		*)
 Set Implicit Arguments.
 
-Require Import Comp.
+Require Import FCF.Comp.
 
 Local Open Scope comp_scope.
 

--- a/src/FCF/NotationV2.v
+++ b/src/FCF/NotationV2.v
@@ -5,7 +5,7 @@ Set Implicit Arguments.
 
 (* An attempt at uniform notation.  It works okay for writing definitions, but eventually you have to leave the monad in a proof, and then you lose the notation.  So this approach probably won't work very well. *)
 
-Require Import Comp.
+Require Import FCF.Comp.
 
 Class Monad
       (M : Set -> Type) :=

--- a/src/FCF/OTP.v
+++ b/src/FCF/OTP.v
@@ -5,7 +5,7 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
+Require Import FCF.FCF.
 
 Definition D := evalDist.
 Definition dist_iso := evalDist_iso.
@@ -176,8 +176,8 @@ End xor_OTP.
 
 
 (* OTP for cyclic groups *)
-Require Import RndNat.
-Require Import RndGrpElem.
+Require Import FCF.RndNat.
+Require Import FCF.RndGrpElem.
 
 Local Open Scope group_scope.
 

--- a/src/FCF/OracleCompFold.v
+++ b/src/FCF/OracleCompFold.v
@@ -4,8 +4,8 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
-Require Import CompFold.
+Require Import FCF.FCF.
+Require Import FCF.CompFold.
 
 Local Open Scope list_scope.
 
@@ -64,7 +64,7 @@ Theorem oc_compMap_eq :
   
 Qed.
 
-Require Import PRF.
+Require Import FCF.PRF.
 
 Theorem compMap_randomFunc_NoDup : 
   forall (A B C: Set){eqda : EqDec A}{eqdb : EqDec B}{eqdc : EqDec C}(ls : list A)(f : A -> B -> Comp C)(rndB : Comp B)(lsf : list (A * B)),

--- a/src/FCF/OracleHybrid.v
+++ b/src/FCF/OracleHybrid.v
@@ -4,9 +4,9 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
+Require Import FCF.FCF.
 (* RndInList has a useful theorem (qam_count) about counting calls to an oracle. *)
-Require Import RndInList. 
+Require Import FCF.RndInList. 
 
 Section OracleHybrid.
 
@@ -345,11 +345,11 @@ End OracleHybrid.
 
 
 (* A specialization that uses OracleHybrid to produce a hybrid argument on non-adaptive oracle interactions *)
-Require Import CompFold.
-Require Import OracleCompFold.
+Require Import FCF.CompFold.
+Require Import FCF.OracleCompFold.
 
 (* oracleMap is defined in PRF.  We should probably find a better place for it. *)       
-Require Import PRF.
+Require Import FCF.PRF.
 
 Section OracleMapHybrid.
 

--- a/src/FCF/PRF.v
+++ b/src/FCF/PRF.v
@@ -5,10 +5,10 @@
 (* Definitions related to pseudoradom functions.  This file copies some items from ConstructedFunc.v, so we probably need to refactor this in the future. *)
 
 Set Implicit Arguments.
-Require Import FCF.
-Require Import CompFold. 
-Require Export Array.
-Require Export Hybrid.
+Require Import FCF.FCF.
+Require Import FCF.CompFold. 
+Require Export FCF.Array.
+Require Export FCF.Hybrid.
 
 Local Open Scope list_scope.
 Local Open Scope array_scope.
@@ -255,8 +255,8 @@ Section PRF_concrete.
   
 End PRF_concrete.
 
-Require Import Asymptotic.
-Require Import Admissibility.
+Require Import FCF.Asymptotic.
+Require Import FCF.Admissibility.
 
 Section PRF.
 

--- a/src/FCF/PRF_Convert.v
+++ b/src/FCF/PRF_Convert.v
@@ -4,9 +4,9 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
-Require Import PRF.
-Require Import CompFold.
+Require Import FCF.FCF.
+Require Import FCF.PRF.
+Require Import FCF.CompFold.
 
 Section PRF_Convert.
 

--- a/src/FCF/PRG.v
+++ b/src/FCF/PRG.v
@@ -5,8 +5,8 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
-Require Import SemEquiv.
+Require Import FCF.FCF.
+Require Import FCF.SemEquiv.
 
 Section OneWayPermutation.
 
@@ -138,7 +138,7 @@ Section PseudorandomGenerator.
   Definition PRG_Advantage := | (Pr[PRG_G1]) - (Pr[PRG_G2]) |.
 End PseudorandomGenerator.
 
-Require Import DetSem.
+Require Import FCF.DetSem.
 
 Section OWP_HCP_Impl_PRG.
 

--- a/src/FCF/ProgTacs.v
+++ b/src/FCF/ProgTacs.v
@@ -6,15 +6,15 @@
 
 Set Implicit Arguments.
 
-Require Import Rat.
-Require Import Comp.
-Require Import DistRules.
-Require Import DistSem.
-Require Import StdNat.
-Require Import Fold.
-Require Import ProgramLogic.
-Require Import DistTacs.
-Require Import NotationV1.
+Require Import FCF.Rat.
+Require Import FCF.Comp.
+Require Import FCF.DistRules.
+Require Import FCF.DistSem.
+Require Import FCF.StdNat.
+Require Import FCF.Fold.
+Require Import FCF.ProgramLogic.
+Require Import FCF.DistTacs.
+Require Import FCF.NotationV1.
 
 Local Open Scope rat_scope.
 Local Open Scope comp_scope.

--- a/src/FCF/ProgramLogic.v
+++ b/src/FCF/ProgramLogic.v
@@ -2,9 +2,9 @@
  * in the LICENSE file at the root of the source tree.		*)
 Set Implicit Arguments.
 
-Require Import Crypto.
-Require Import Bernoulli.
-Require Import NotationV1.
+Require Import FCF.Crypto.
+Require Import FCF.Bernoulli.
+Require Import FCF.NotationV1.
 
 (* stuff that needs to go somewhere else *)
 

--- a/src/FCF/Rat.v
+++ b/src/FCF/Rat.v
@@ -6,7 +6,7 @@ Set Implicit Arguments.
 
 Require Import Omega.
 Require Import List.
-Require Import StdNat.
+Require Import FCF.StdNat.
 Require Import Arith.
 Require Import Lia.
 

--- a/src/FCF/RepeatCore.v
+++ b/src/FCF/RepeatCore.v
@@ -12,10 +12,10 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
-Require Import CompFold.
-Require Import RndNat.
-Require Export Hybrid.
+Require Import FCF.FCF.
+Require Import FCF.CompFold.
+Require Import FCF.RndNat.
+Require Export FCF.Hybrid.
 
 Local Open Scope list_scope.
 

--- a/src/FCF/RndDup.v
+++ b/src/FCF/RndDup.v
@@ -3,8 +3,8 @@
 
 (* A basic argument about encountering a specific value in a list of randomly-generated values. *)
 
-Require Import FCF.
-Require Import CompFold.
+Require Import FCF.FCF.
+Require Import FCF.CompFold.
 
 Section RndDup.
 

--- a/src/FCF/RndGrpElem.v
+++ b/src/FCF/RndGrpElem.v
@@ -4,8 +4,8 @@
 
 
 (* Sampling an element from a finite cyclic group *)
-Require Import FCF.
-Require Export GroupTheory.
+Require Import FCF.FCF.
+Require Export FCF.GroupTheory.
 
 Local Open Scope group_scope.
 

--- a/src/FCF/RndInList.v
+++ b/src/FCF/RndInList.v
@@ -4,7 +4,7 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
+Require Import FCF.FCF.
 
 Local Open Scope nat_scope.
 
@@ -586,7 +586,7 @@ Theorem RndNat_eq_any :
 
 Qed.
 
-Require Import CompFold.
+Require Import FCF.CompFold.
 Local Opaque evalDist.
 
 Section FixedInRndList.

--- a/src/FCF/RndListElem.v
+++ b/src/FCF/RndListElem.v
@@ -6,7 +6,7 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
+Require Import FCF.FCF.
 
 Section RndListElem.
 

--- a/src/FCF/RndNat.v
+++ b/src/FCF/RndNat.v
@@ -6,9 +6,9 @@
 
 Set Implicit Arguments.
 
-Require Import Crypto.
+Require Import FCF.Crypto.
 Require Import Permutation.
-Require Import NotationV1.
+Require Import FCF.NotationV1.
   
 Definition RndNat_unchecked(n : nat) :=
   v <-$ {0,1} ^ (lognat n);

--- a/src/FCF/RndPerm.v
+++ b/src/FCF/RndPerm.v
@@ -4,9 +4,9 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
-Require Import CompFold.
-Require Import RndListElem.
+Require Import FCF.FCF.
+Require Import FCF.CompFold.
+Require Import FCF.RndListElem.
 Require Import Permutation.
 
 Local Open Scope list_scope.

--- a/src/FCF/SemEquiv.v
+++ b/src/FCF/SemEquiv.v
@@ -5,14 +5,14 @@
 
 Set Implicit Arguments.
 
-Require Import Comp.
-Require Import DetSem.
-Require Import DistSem.
-Require Import Rat.
+Require Import FCF.Comp.
+Require Import FCF.DetSem.
+Require Import FCF.DistSem.
+Require Import FCF.Rat.
 Require Import Arith.
-Require Import StdNat.
-Require Import Fold.
-Require Import Limit.
+Require Import FCF.StdNat.
+Require Import FCF.Fold.
+Require Import FCF.Limit.
 Require Import Permutation.
 
 Local Open Scope rat_scope.

--- a/src/FCF/Signature.v
+++ b/src/FCF/Signature.v
@@ -1,5 +1,5 @@
 Set Implicit Arguments.
-Require Import FCF.
+Require Import FCF.FCF.
 
 Local Open Scope list_scope.
 

--- a/src/FCF/SplitVector.v
+++ b/src/FCF/SplitVector.v
@@ -4,9 +4,9 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
-Require Import SemEquiv.
-Require Import DetSem.
+Require Import FCF.FCF.
+Require Import FCF.SemEquiv.
+Require Import FCF.DetSem.
 
 Fixpoint splitVector(A : Set)(n m : nat) : Vector.t A (n + m) -> (Vector.t A n * Vector.t A m) :=
   match n with

--- a/src/FCF/Tactics.v
+++ b/src/FCF/Tactics.v
@@ -3,11 +3,11 @@
  * in the LICENSE file at the root of the source tree.		*)
 Set Implicit Arguments.
 
-Require Import Crypto.
-Require Import DistTacs.
-Require Import ProgTacs.
-Require Import GenTacs.
-Require Import ProgramLogic.
+Require Import FCF.Crypto.
+Require Import FCF.DistTacs.
+Require Import FCF.ProgTacs.
+Require Import FCF.GenTacs.
+Require Import FCF.ProgramLogic.
 
 
 (** * Tactics Overview *)

--- a/src/FCF/TwoWorldsEquiv.v
+++ b/src/FCF/TwoWorldsEquiv.v
@@ -6,9 +6,9 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
-Require Import Crypto.
-Require Import Asymptotic.
+Require Import FCF.FCF.
+Require Import FCF.Crypto.
+Require Import FCF.Asymptotic.
 
 Theorem evalDist_bool_support : 
   forall (c : Comp bool)(ls : list bool),

--- a/src/FCF/WC_PolyTime.v
+++ b/src/FCF/WC_PolyTime.v
@@ -5,8 +5,8 @@
 
 Set Implicit Arguments.
 
-Require Import FCF.
-Require Import Admissibility.
+Require Import FCF.FCF.
+Require Import FCF.Admissibility.
 
 Local Open Scope nat_scope.
 
@@ -294,7 +294,7 @@ Ltac costtac_one :=
 
 Ltac costtac := repeat (costtac_one).
 
-Require Import Asymptotic.
+Require Import FCF.Asymptotic.
 
 Definition poly_time_nonuniform_oc(cost : FunctionCostModel)(A B C : nat -> Set)(c : forall n, OracleComp (A n) (B n) (C n)) := 
   exists (f : nat -> nat -> nat), 

--- a/src/FCF/WC_PolyTime_old.v
+++ b/src/FCF/WC_PolyTime_old.v
@@ -4,7 +4,7 @@
 
 (* An efficiency predicate that characterizes of non-uniform PPT turing machines.  *)
 
-Require Import Crypto.
+Require Import FCF.Crypto.
 Set Implicit Arguments.
 
 Definition CostModel := forall (A B : Type), (A -> B) -> nat -> Prop.
@@ -303,7 +303,7 @@ Section constant_cost_theory.
   
 End constant_cost_theory.
 
-Require Import Asymptotic.
+Require Import FCF.Asymptotic.
 
 Definition poly_time_nonuniform(cost : CostModel)(A B : nat -> Type)(f : forall n, (A n) -> (B n)) :=
   exists x, polynomial x /\


### PR DESCRIPTION
This changes makes it easier to import FCF into another project without polluting namespaces.  Now, every file in FCF imports other files in FCF by, e.g.,
`Require Import FCF.Comp.
`instead of 
`Require Import Comp.
`