### PR TITLE
Avoid relying on `Export` bugs

### DIFF
--- a/src/FCF/DistSem.v
+++ b/src/FCF/DistSem.v
@@ -14,7 +14,7 @@ Require Import FCF.Blist.
 Require Import Omega.
 Require Import FCF.StdNat.
 Require Import FCF.NotationV1.
- 
+Require Import FCF.EqDec. 
  
 Local Open Scope list_scope.
 Local Open Scope rat_scope.


### PR DESCRIPTION
See https://github.com/coq/coq/issues/10474 and
https://github.com/coq/coq/issues/10480

This is in preparation for coq/coq#10476 which fixes these two bugs, and is backward compatible (tested on Coq's master).