### PR TITLE
compatibility with Coq PR 11906

### DIFF
--- a/src/FCF/Rat.v
+++ b/src/FCF/Rat.v
@@ -3491,7 +3491,8 @@ Lemma rat_le_1_if :
   destruct d.
   rewrite mult_1_r in H.
   rewrite mult_1_l in H.
-  destruct (le_gt_dec n x); intuition.
+  destruct (le_gt_dec n x).
+  omega.
   discriminate.
   
 Qed.


### PR DESCRIPTION
Coq PR #11906 extends `lia` with support for boolean operators.
This has the consequence that `intuition` is able to perform some
boolean reasoning e.g. true = false -> _.
The PR replaces a `_ ; intuition` by `_ . omega. discriminate.`