### PR TITLE
do not depend on Coq.Bool.Bvector

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -5,6 +5,7 @@ src/FCF/Array.v
 src/FCF/Asymptotic.v
 src/FCF/Bernoulli.v
 src/FCF/Blist.v
+src/FCF/Bvector.v
 src/FCF/Class.v
 src/FCF/Comp.v
 src/FCF/CompFold.v

--- a/src/FCF/Bvector.v
+++ b/src/FCF/Bvector.v
@@ -1,0 +1,6 @@
+Require Coq.Vectors.Vector.
+Export Bool Vector.VectorNotations.
+
+Definition Bvector := Vector.t bool.
+Definition Bvect_false := Vector.const false.
+Definition BVxor := @Vector.map2 _ _ _ xorb.


### PR DESCRIPTION
I am investigating whether we could remove Bvector (specialization of Vector to Bool) from stdlib. This is the part that FCF actually uses.

~~Feel free to ignore for now or merge right away.~~